### PR TITLE
Fixed function call to `ib` package

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ function next() {
 function requestHistory() {
 	console.log("[PROGRESS: REQUESTED] ".yellow + endDate.format("YYYYMMDD HH:mm:ss"));
 	requestId++;
-	ibMonitor.reqHistoricalData(requestId, ticker, endDate.format("YYYYMMDD HH:mm:ss"), SIZE_TABLE[config.size], config.size, config.what, 0, 2);
+	ibMonitor.reqHistoricalData(requestId, ticker, endDate.format("YYYYMMDD HH:mm:ss"), SIZE_TABLE[config.size], config.size, config.what, 0, 2, false);
 	timestamps.push(new Date());
 }
 


### PR DESCRIPTION
There was now a missing argument in `reqHistoricalData`. The last parameter is a boolean called `keepUpToDate`. Keeping it true would mean that IBKR streams data as it is being updated in real time.

Since this library is about downloading strictly historical data, I hardcoded this value as `false`. 

Without this boolean, the library does not run.