### PR TITLE
Bugfix for writing same information to file

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,7 @@ var ibMonitor = new ib({
 					var line = util.format("%s,%s,%s,%s,%s,%s,%s,%s\n", entry.date, ticker.symbol, config.what, entry.open, entry.high, entry.low, entry.close, entry.volume);
 					fs.writeFileSync(util.format("%s_%s.csv", ticker.symbol, ticker.secType), line, { flag: "a" });
 				}
+				history = [];
 
 				// Next round
 				next();


### PR DESCRIPTION
Because the library appends to the history file as we get the data, we have to clear out history cache to avoid writing the same data (that we have already downloaded) in the next loop.

Another alternative would be to only write to the file once, when all desired historical data has been downloaded. I decided to opt for this easier to implement approach.